### PR TITLE
[UNTESTED] Added custom Protocol normalizer

### DIFF
--- a/gameq/filters/normalise.php
+++ b/gameq/filters/normalise.php
@@ -122,6 +122,19 @@ class GameQ_Filters_Normalise extends GameQ_Filters
 
         unset($result['gq_players'], $result['gq_teams']);
 
+        // Apply the custom/more specific normalizer
+        if(!empty($this->params))
+        {
+            foreach($this->params as $normalizerName)
+            {
+                $className = 'GameQ_Filters_Normalizer_Ts3_'.ucfirst($normalizerName);
+
+                /** @var $normalizer GameQ_Filters_Normalizer_Core */
+                $normalizer = new $className();
+                
+                $result = $normalizer->normalize($result);
+            }
+        }
 
         // Merge and sort array
         $result = (array_merge($data, $result));

--- a/gameq/filters/normalise.php
+++ b/gameq/filters/normalise.php
@@ -127,12 +127,17 @@ class GameQ_Filters_Normalise extends GameQ_Filters
         {
             foreach($this->params as $normalizerName)
             {
-                $className = 'GameQ_Filters_Normalizer_Ts3_'.ucfirst($normalizerName);
+                $className = 'GameQ_Filters_Normalizer_'.ucfirst($protocol_instance->name()).'_'.ucfirst($normalizerName);
 
-                /** @var $normalizer GameQ_Filters_Normalizer_Core */
-                $normalizer = new $className();
-                
-                $result = $normalizer->normalize($result);
+                try{
+                    /** @var $normalizer GameQ_Filters_Normalizer_Core */
+                    $normalizer = new $className();
+
+                    $result = $normalizer->normalize($result);
+                }catch (Exception $e)
+                {
+                    // ignore, as this filter does not exist.
+                }
             }
         }
 

--- a/gameq/filters/normalizer/core.php
+++ b/gameq/filters/normalizer/core.php
@@ -1,0 +1,6 @@
+<?php
+
+abstract class GameQ_Filters_Normalizer_Core
+{
+    abstract public function normalize($data);
+}

--- a/gameq/filters/normalizer/ts3/playerchannel.php
+++ b/gameq/filters/normalizer/ts3/playerchannel.php
@@ -1,0 +1,34 @@
+<?php
+
+class GameQ_Filters_Normalizer_Ts3_Playerchannel extends GameQ_Filters_Normalizer_Core
+{
+
+    /**
+     * Normalize the array key of clients and channels to their respective id
+     *
+     * @param array $data The unmodified data we want to filter.
+     *
+     * @return array The modified data which has our filter applied.
+     */
+    public function normalize($data)
+    {
+        // normalize clients
+        $players = array();
+        foreach($data['players'] as $player)
+        {
+            $players[$player['clid']] = $player;
+        }
+        $data['players'] = $players;
+
+        // normalize channels
+        $channels = array();
+        foreach($data['teams'] as $channel)
+        {
+            $channels[$channel['cid']] = $channel;
+        }
+        $data['teams'] = $channels;
+
+        return $data;
+    }
+
+}


### PR DESCRIPTION
I thought about the Issue #61 and how we can decouple the additional
filters for our protocol so we have a more detached manner of
normalisation. This branch is a suggestion how we could add some
pluggable mechanism to this. We use the current unused parameters of the
normalise filter. We just insert a array with some values which protocol
specific normalisation should be done. I think this is - somehow - a
clean way to do this but I thought if it is not the same we already have
with the filters, but for this case in a more categorized way. (we could
in fact implement each of those normalizer as own filters, but then copy
some logic from the current/default normalise filter.

I also thought about having pluggable generic normalizer which could be
pluggable, but I don't know if there is any use-case for that. We would
then to have some key/value pair of params to normalize which
normalizers we want to load/apply on our data.

I also changed the way I modify the data from #61, as we now use a copy
and return the changed array after that. This is a bit slower as some
copying has to be made and we could easily adapt that to by-reference
but I would suggest to only do that if we discussed about that
beforehand.

Hopefully this is some kind of the way you thought about doing the whole
thing. We could now add generic normalizer for each protocol which could
filter the settings we have inside the Protocol::$normazie at the moment.

Those generic protocol normalizer could be used through naming by
convention and thus having like 'GameQ_Filters_Normalizer_Ts3', whereas
Ts3 is the ucfirst of the name of the given protocol so we will not have
to specify the generic normalisation (which we do through $normalize
'overload/overwrite' atm).

Some thoughts about all of this? Did I messed up your idea or did I hit
some good spot with this implementation? (As sperating of the whole
normalisation from the protocol is now possible)
