### PR TITLE
fix query port for rust and 7d2d protocols

### DIFF
--- a/gameq/protocols/7d2d.php
+++ b/gameq/protocols/7d2d.php
@@ -38,7 +38,7 @@ class GameQ_Protocols_7d2d extends GameQ_Protocols_Source
 	    // Got to do this first
 	    parent::__construct($ip, $port, $options);
 
-	    // Correct the client port since query_port = client_port + 1
-	    $this->port_client(($this->port_client() - 1));
+	    // Correct the client port since query_port = port + 1
+	    $this->port(($this->port() + 1));
 	}
 }

--- a/gameq/protocols/rust.php
+++ b/gameq/protocols/rust.php
@@ -40,7 +40,7 @@ class GameQ_Protocols_Rust extends GameQ_Protocols_Source
 	    // Got to do this first
 	    parent::__construct($ip, $port, $options);
 
-	    // Correct the client port since query_port = client_port + 1
-	    $this->port_client(($this->port_client() - 1));
+	    // Correct the client port since query_port = port + 1
+	    $this->port(($this->port() + 1));
 	}
 }


### PR DESCRIPTION
Hi!
Thank you for support "Rust" and "7 Days to Die" games.
But it's not working for me.
Because I think there was a bug with query ports for those games.
query_port = port + 1, 
but you used  

``` php
$this->port_client(($this->port_client() - 1));
```

I fixed it and test this changes. Now rust and 7d2d servers working fine. I take servers for test from http://www.gametracker.com//search/rust/ and http://www.gametracker.com//search/7d2d/ 
Please take my pull request.
Thank you!
