### PR TITLE
Killing Floor doesn’t populate game_descr, fix that

### DIFF
--- a/gameq/protocols/killingfloor.php
+++ b/gameq/protocols/killingfloor.php
@@ -50,6 +50,7 @@ class GameQ_Protocols_Killingfloor extends GameQ_Protocols_Unreal2
 	    // Create a buffer
 	    $buf = new GameQ_Buffer($data);
 
+	    $result->add('game_descr',  $this->name_long);
 	    $result->add('serverid',    $buf->readInt32());          // 0
 	    $result->add('serverip',    $buf->readPascalString(1));  // empty
 	    $result->add('gameport',    $buf->readInt32());


### PR DESCRIPTION
Kinda new to GameQ, and unsure where the best place to fix this is?

Before this fix, we weren’t getting this field populated, instead having
to detect gq_type and fill it in ourselves.
