### PR TITLE
added check for 64 bit PHP

### DIFF
--- a/src/GameQ/Buffer.php
+++ b/src/GameQ/Buffer.php
@@ -437,7 +437,7 @@ class Buffer
     {
 
         // We have the pack 64-bit codes available. See: http://php.net/manual/en/function.pack.php
-        if (version_compare(PHP_VERSION, '5.6.3') >= 0) {
+        if (version_compare(PHP_VERSION, '5.6.3') >= 0 && PHP_INT_SIZE == 8) {
             // Change the integer type we are looking up
             switch ($this->number_type) {
                 case self::NUMBER_TYPE_BIGENDIAN:


### PR DESCRIPTION
On 32bit machine the unpack method shows the following warning:
`PHP Warning:  unpack(): 64-bit format codes are not available for 32-bit versions of PHP in Buffer.php on line 455`
By adding an extra check for the size of `int` these warnings can be avoided
