### PR TITLE
Fix gamespy3 protocol bug when server name contains \u0000 string

### DIFF
--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -141,8 +141,13 @@ class Gamespy3 extends Protocol
         // Offload cleaning up the packets if they happen to be split
         $packets = $this->cleanPackets(array_values($processed));
 
+         // Fix: when server name contains string "\u0000" - query fails.
+        // "\u0000" also separates properties from server, so we are 
+        // replacing double "\u0000" in server response.
+        $packets = preg_replace("/(\\x00){2,}gametype/","\x00gametype", implode('', $packets));
+
         // Create a new buffer
-        $buffer = new Buffer(implode('', $packets), Buffer::NUMBER_TYPE_BIGENDIAN);
+        $buffer = new Buffer($packets, Buffer::NUMBER_TYPE_BIGENDIAN);
 
         // Create a new result
         $result = new Result();


### PR DESCRIPTION
I tested it on Minecraft Protocol Class that extends Gamespy3 with Minecraft server (Vanilla 1.10.2). Server sometimes adds after restart '\u0000' to server name (named motd) in config (file server.properties) with no reason and with that string in name, GameQ responds with wrong formated informations.
