### PR TITLE
fix Gamespy3 protocol

### DIFF
--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -83,16 +83,23 @@ class Gamespy3 extends Protocol
      */
     public function challengeParseAndApply(Buffer $challenge_buffer)
     {
-
         // Pull out the challenge
         $challenge = substr(preg_replace("/[^0-9\-]/si", "", $challenge_buffer->getBuffer()), 1);
-        $challenge_result = sprintf(
-            "%c%c%c%c",
-            ($challenge >> 24),
-            ($challenge >> 16),
-            ($challenge >> 8),
-            ($challenge >> 0)
-        );
+
+        // By default, no challenge result (see #197) 
+        $challenge_result = '';
+
+        // Check for valid challenge (see #197)
+        if( $challenge )
+        {
+            $challenge_result = sprintf(
+                "%c%c%c%c",
+                ($challenge >> 24),
+                ($challenge >> 16),
+                ($challenge >> 8),
+                ($challenge >> 0)
+            );
+        }
 
         // Apply the challenge and return
         return $this->challengeApply($challenge_result);

--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -90,8 +90,8 @@ class Gamespy3 extends Protocol
         $challenge_result = '';
 
         // Check for valid challenge (see #197)
-        if( $challenge )
-        {
+        if ($challenge) {
+            // Encode chellenge result
             $challenge_result = sprintf(
                 "%c%c%c%c",
                 ($challenge >> 24),


### PR DESCRIPTION
## Description

See #197. If the server (for instance Crysis Wars) has no connection to the Gamespy master server, it will not respond with a challenge in the expected format. However, if you leave out the challenge in the subsequent request, you can still query the server information.

## Reproduction

Use the following test script for example:
```php
<?php

require_once('vendor/autoload.php');

$gq = new \GameQ\GameQ(); 
$gq->addServers([
	[
		'type' => 'gamespy3',
		'host' => '138.201.128.96:64100'
	]
]);

$gqresults = $gq->process();

var_dump($gqresults);
```
The used server (`138.201.128.96:64100` _=CJW=Funbocks Alpha|mixed maps_) will not be able to be queried without this fix, due to the missing Gamespy connection resulting in a challenge response of `"0"`.

### Expected result

`"gq_online"` will be `true` and all other server information is available.

### Actual result

`"gq_online"` is `false` and not further server information is available.

## Fix

This PR adds a check if a challenge was successfully extracted from the challenge buffer and only then processes the challenge result. Otherwise the challenge result will be empty by default and thus simply omitted in the subsequent request.

Without this change, no Crysis Wars server will be able to queried otherwise, since the Gamespy Network is not existant anymore and Crysis Wars for example can be patched to use Qtracker instead.