### PR TITLE
fix filter dont working if string is utf8 encoded

### DIFF
--- a/src/GameQ/Filters/Stripcolors.php
+++ b/src/GameQ/Filters/Stripcolors.php
@@ -95,6 +95,6 @@ class Stripcolors extends Base
      */
     protected function stripUnreal(&$string)
     {
-        $string = preg_replace('/\x1b.../', '', $string);
+        $string = utf8_encode(preg_replace('/\x1b.../', '', utf8_decode($string)));
     }
 }

--- a/src/GameQ/Filters/Stripcolors.php
+++ b/src/GameQ/Filters/Stripcolors.php
@@ -93,8 +93,9 @@ class Stripcolors extends Base
      *
      * @param string $string
      */
-    protected function stripUnreal(&$string)
+    protected function stripUnreal(&$string, &$key)
     {
         $string = utf8_encode(preg_replace('/\x1b.../', '', utf8_decode($string)));
+        $key = utf8_encode(preg_replace('/\x1b.../', '', utf8_decode($key)));
     }
 }


### PR DESCRIPTION
query server 188.234.213.9:7900 (killingfloor) query port +1
color codes are not removed. 