### PR TITLE
Added protocols directory name as constant

### DIFF
--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -43,6 +43,7 @@ class GameQ
     /*
      * Constants
      */
+    const PROTOCOLS_DIRECTORY = __DIR__ . '/Protocols';
 
     /* Static Section */
 


### PR DESCRIPTION
This fix is needed for projects that use _GameQ_ so that they can get a list of protocols