### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/src/GameQ/Buffer.php
+++ b/src/GameQ/Buffer.php
@@ -151,7 +151,7 @@ class Buffer
     {
 
         $len = strlen($this->data);
-        $string = $this->data{strlen($this->data) - 1};
+        $string = $this->data[strlen($this->data) - 1];
         $this->data = substr($this->data, 0, $len - 1);
         $this->length -= 1;
 


### PR DESCRIPTION
Fix PHP 7.4 compatibility:
- [x] Replaced curly string access to brackets since it is [deprecated since PHP 7.4](https://wiki.php.net/rfc/deprecate_curly_braces_array_access)