### PR TITLE
Update Rust protocol to get correct players when > 256

### DIFF
--- a/src/GameQ/Protocols/Rust.php
+++ b/src/GameQ/Protocols/Rust.php
@@ -50,11 +50,9 @@ class Rust extends Source
      */
     protected function processDetails(Buffer $buffer)
     {
-
         $results = parent::processDetails($buffer);
-        
-        if($results['keywords'])
-        {
+
+        if ($results['keywords']) {
             //get max players from mp of keywords and num players from cp keyword
             preg_match_all('/(mp|cp)([\d]+)/', $results['keywords'], $matches);
             $results['max_players'] = intval($matches[2][0]);
@@ -62,6 +60,5 @@ class Rust extends Source
         }
 
         return $results;
-          
     }
 }

--- a/src/GameQ/Protocols/Rust.php
+++ b/src/GameQ/Protocols/Rust.php
@@ -19,7 +19,6 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
-use GameQ\Result;
 
 /**
  * Class Rust

--- a/src/GameQ/Protocols/Rust.php
+++ b/src/GameQ/Protocols/Rust.php
@@ -18,6 +18,9 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Buffer;
+use GameQ\Result;
+
 /**
  * Class Rust
  *
@@ -42,21 +45,24 @@ class Rust extends Source
     protected $name_long = "Rust";
     
     /**
-     * Overload so we can take max_players from keywords
+     * Overload so we can get max players from mp of keywords and num players from cp keyword
      *
      * @param Buffer $buffer
-     * @param Result $result
      */
-    protected function processDetails(Buffer &$buffer, Result &$result)
+    protected function processDetails(Buffer $buffer)
     {
-        parent::processDetails($buffer, $result);
+
+        $results = parent::processDetails($buffer);
         
-        if($result->get('keywords')
+        if($results['keywords'])
         {
-            //get max players from mp of keywords
-            preg_match_all('/mp([\d]+)/', $result->get('keywords'), $matches);
-            $result->add('max_players', intval($matches[1]));
+            //get max players from mp of keywords and num players from cp keyword
+            preg_match_all('/(mp|cp)([\d]+)/', $results['keywords'], $matches);
+            $results['max_players'] = intval($matches[2][0]);
+            $results['num_players'] = intval($matches[2][1]);
         }
+
+        return $results;
           
     }
 }

--- a/src/GameQ/Protocols/Rust.php
+++ b/src/GameQ/Protocols/Rust.php
@@ -40,4 +40,23 @@ class Rust extends Source
      * @type string
      */
     protected $name_long = "Rust";
+    
+    /**
+     * Overload so we can take max_players from keywords
+     *
+     * @param Buffer $buffer
+     * @param Result $result
+     */
+    protected function processDetails(Buffer &$buffer, Result &$result)
+    {
+        parent::processDetails($buffer, $result);
+        
+        if($result->get('keywords')
+        {
+            //get max players from mp of keywords
+            preg_match_all('/mp([\d]+)/', $result->get('keywords'), $matches);
+            $result->add('max_players', intval($matches[1]));
+        }
+          
+    }
 }


### PR DESCRIPTION
With servers over 256 players, the max_players and num_players fields show wrong number. This is because Source can only send 128*2 for player info.

 Rust creates keywords to save player count so use this instead of what's returned from source.