### PR TITLE
Comply class names with psr-4 autoloading standard.

### DIFF
--- a/src/GameQ/Protocols/Egs.php
+++ b/src/GameQ/Protocols/Egs.php
@@ -25,7 +25,7 @@ namespace GameQ\Protocols;
  * @author  Austin Bischoff <austin@codebeard.com>
  * @author  TacTicToe66 <https://github.com/TacTicToe66>
  */
-class EgS extends Source
+class Egs extends Source
 {
 
     /**

--- a/src/GameQ/Protocols/Serioussam.php
+++ b/src/GameQ/Protocols/Serioussam.php
@@ -23,7 +23,7 @@ namespace GameQ\Protocols;
  *
  * @author ZCaliptium <zcaliptium@gmail.com>
  */
-class SeriousSam extends Gamespy
+class Serioussam extends Gamespy
 {
 
     /**


### PR DESCRIPTION
This pull fixes warnings that prevent these protocols from loading in composer 2.0.