### PR TITLE
Extend `.gitattributes` to clean up release builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,15 @@
 * text=auto
 
 /build export-ignore
+/examples export-ignore
 /tests export-ignore
 /.coveralls.yml export-ignore
 /.scrutinizer.yml export-ignore
+/.github export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml export-ignore
 /phpunit.xml.dist export-ignore
+/CONTRIBUTING.md export-ignore
 /README.md export-ignore


### PR DESCRIPTION
These files shouldn't be added whenever you run `composer install` to install the package.