### PR TITLE
Custom parameters

### DIFF
--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -616,6 +616,7 @@ class GameQ
         $results['gq_type'] = (string)$server->protocol();
         $results['gq_name'] = $server->protocol()->nameLong();
         $results['gq_transport'] = $server->protocol()->transport();
+        $results['gq_custom'] = $server->getCustom();
 
         // Process the join link
         if (!isset($results['gq_joinlink']) || empty($results['gq_joinlink'])) {

--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -125,8 +125,10 @@ class GameQ
     public function __construct()
     {
         // Check for missing utf8_encode function
-        if (!function_exists('utf8_encode')) {
-            throw new \Exception("PHP's utf8_encode() function is required - "
+
+        // Deprecached utf8_encode
+        if (!function_exists('mb_convert_encoding')) {
+            throw new \Exception("PHP's mb_convert_encoding() function is required - "
                 . "http://php.net/manual/en/function.utf8-encode.php.  Check your php installation.");
         }
     }

--- a/src/GameQ/Protocol.php
+++ b/src/GameQ/Protocol.php
@@ -253,8 +253,11 @@ abstract class Protocol
      */
     public function findQueryPort($clientPort)
     {
-
-        return $clientPort + $this->port_diff;
+        if(!$this->protocol != 'discord'){
+            return $clientPort + $this->port_diff;
+        }else{
+            return 1;
+        }
     }
 
     /**

--- a/src/GameQ/Protocols/Codmw2.php
+++ b/src/GameQ/Protocols/Codmw2.php
@@ -63,7 +63,7 @@ class Codmw2 extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $player['name'] = utf8_encode(trim(($playerInfo->readString('"'))));
+            $player['name'] = mb_convert_encoding(trim(($playerInfo->readString('"'))), 'UTF-8');
 
             // Add player
             $players[] = $player;

--- a/src/GameQ/Protocols/Cs2d.php
+++ b/src/GameQ/Protocols/Cs2d.php
@@ -200,8 +200,9 @@ class Cs2d extends Protocol
         $result->add('lua_scripts', (int)$this->readFlag($serverFlags, 6));
 
         // Read the rest of the buffer data
-        $result->add('servername', utf8_encode($buffer->readPascalString(0)));
-        $result->add('mapname', utf8_encode($buffer->readPascalString(0)));
+        // mb_convert_encoding($string, 'UTF-8');
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(0), 'UTF-8'));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(0), 'UTF-8'));
         $result->add('num_players', $buffer->readInt8());
         $result->add('max_players', $buffer->readInt8());
         $result->add('game_mode', $buffer->readInt8());
@@ -236,7 +237,7 @@ class Cs2d extends Protocol
             if (($id = $buffer->readInt8()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString(0)));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(0), 'UTF-8'));
                 $result->addPlayer('team', $buffer->readInt8());
                 $result->addPlayer('score', $buffer->readInt32());
                 $result->addPlayer('deaths', $buffer->readInt32());

--- a/src/GameQ/Protocols/Discord.php
+++ b/src/GameQ/Protocols/Discord.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * This file is part of GameQ.
+ *
+ * GameQ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GameQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * ! THIS PART IS HARDCODED DISCORD STATUS
+ * ! NOT FINAL VERSION
+ * ! NO TEST AVAILABLE...
+ * ! THERE IS NO OPTIONS FOR CUSTOMIZE / NORMALIZE PARAMS
+ * 
+ * ! DIDNT TEST: https://github.com/Austinb/GameQ/wiki/Configuration-v3#filters
+ * ! NOT SURE IF ANY OF THIS WILL WORK.
+ */
+
+namespace GameQ\Protocols;
+
+use GameQ\Exception\Protocol as Exception;
+use GameQ\Result;
+use GameQ\Protocol;
+
+/**
+ * ECO Global Survival Protocol Class
+ *
+ * @author Austin Bischoff <austin@codebeard.com>
+ */
+class Discord extends Protocol
+{
+    /**
+     * The protocol being used
+     *
+     * @var string
+     */
+    protected $protocol = 'discord';
+
+    /**
+     * String name of this protocol class
+     *
+     * @var string
+     */
+    protected $name = 'discord';
+
+    /**
+     * Longer string name of this protocol class
+     *
+     * @var string
+     */
+    protected $name_long = "Discord";
+
+    /**
+     * query_port = client_port + 1
+     *
+     * @type int
+     */
+    protected $port_diff = 0;
+
+    /**
+     * Process the response
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function processResponse()
+    {
+        $discord = curl_init('');
+        curl_setopt($discord, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($discord, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($discord, CURLOPT_CONNECTTIMEOUT, 5.0);
+        curl_setopt($discord, CURLOPT_TIMEOUT, 3);
+        curl_setopt($discord, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+        curl_setopt(
+            $discord,
+            CURLOPT_URL,
+            "https://discord.com/api/v10/invites/{$this->options['invite']}?with_counts=true"
+        );
+
+        $buffer = curl_exec($discord);
+        $buffer = json_decode($buffer, true);
+
+        $result = new Result();
+
+        // Server is always dedicated
+        $result->add('gq_joinlink', "https://discord.gg/{$this->options['invite']}");
+        $result->add('gq_address', "https://discord.gg/{$this->options['invite']}");
+
+        // gq_
+        $result->add('num_players', $buffer['approximate_presence_count']);
+        $result->add('max_players', $buffer['approximate_member_count']);
+        $result->add('dedicated', 1);
+        $result->add('servername', $buffer['guild']['name']);
+        $result->add('map', 'discord');
+        $result->add('game', 'discord');
+        $result->add('matchtype', 'discord');
+        $result->add('passsord', false);
+
+        // Others
+        $result->add('dd_guildid', $buffer['guild']['id']);
+        $result->add('dd_description', $buffer['guild']['description']);
+        $result->add('dd_nsfw', $buffer['guild']['nsfw']);
+        $result->add('dd_features', implode(', ', $buffer['guild']['features']));
+        $result->add('dd_nsfw', $buffer['guild']['nsfw']);
+        if (isset($buffer['inviter'])) {
+            $result->add('dd_inviter', $buffer['inviter']['username'] . "#" . $buffer['inviter']['discriminator']);
+        }
+        return $result->fetch();
+    }
+}

--- a/src/GameQ/Protocols/Doom3.php
+++ b/src/GameQ/Protocols/Doom3.php
@@ -166,8 +166,7 @@ class Doom3 extends Protocol
         // Key / value pairs, delimited by an empty pair
         while ($buffer->getLength()) {
             $key = trim($buffer->readString());
-            $val = utf8_encode(trim($buffer->readString()));
-
+            $val = mb_convert_encoding(trim($buffer->readString()), 'UTF-8');
             // Something is empty so we are done
             if (empty($key) && empty($val)) {
                 break;
@@ -204,8 +203,7 @@ class Doom3 extends Protocol
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString())));
-
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), 'UTF-8'));
             // Increment
             $playerCount++;
         }

--- a/src/GameQ/Protocols/Gamespy.php
+++ b/src/GameQ/Protocols/Gamespy.php
@@ -159,7 +159,7 @@ class Gamespy extends Protocol
                         if (substr($key, 0, $suffix) == 'playername') {
                             $numPlayers++;
                         }
-                        $result->addPlayer(substr($key, 0, $suffix), utf8_encode($val));
+                        $result->addPlayer(substr($key, 0, $suffix), mb_convert_encoding($val, 'UTF-8'));
                     }
                 } else {
                     // Regular variable so just add the value.

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -182,7 +182,7 @@ class Gamespy2 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, utf8_encode($buffer->readString()));
+            $result->add($key, mb_convert_encoding($buffer->readString(), 'UTF-8'));
         }
 
         unset($buffer);
@@ -256,7 +256,11 @@ class Gamespy2 extends Protocol
         // Get the values
         while ($buffer->getLength() > 4) {
             foreach ($varNames as $varName) {
-                $result->addSub($dataType, utf8_encode($varName), utf8_encode($buffer->readString()));
+                $result->addSub(
+                    $dataType, 
+                    mb_convert_encoding($varName, 'UTF-8'), 
+                    mb_convert_encoding($buffer->readString(), 'UTF-8')
+                );
             }
             if ($buffer->lookAhead() === "\x00") {
                 $buffer->skip();

--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -252,7 +252,7 @@ class Gamespy3 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, utf8_encode($buffer->readString()));
+            $result->add($key, mb_convert_encoding($buffer->readString(), 'UTF-8'));
         }
     }
 
@@ -328,7 +328,7 @@ class Gamespy3 extends Protocol
                         break;
                     }
                     // Add the value to the proper item in the correct group
-                    $result->addSub($item_group, $item_type, utf8_encode(trim($val)));
+                    $result->addSub($item_group, $item_type, mb_convert_encoding(trim($val), 'UTF-8'));
                 }
                 // Unset our buffer
                 unset($buf_temp);

--- a/src/GameQ/Protocols/Killingfloor.php
+++ b/src/GameQ/Protocols/Killingfloor.php
@@ -80,10 +80,10 @@ class Killingfloor extends Unreal2
         $buffer->skip(1);
 
         // Read as a regular string since the length is incorrect (what we skipped earlier)
-        $result->add('servername', utf8_encode($buffer->readString()));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
 
         // The rest is read as normal
-        $result->add('mapname', utf8_encode($buffer->readPascalString(1)));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), 'UTF-8'));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());

--- a/src/GameQ/Protocols/Lhmp.php
+++ b/src/GameQ/Protocols/Lhmp.php
@@ -171,10 +171,10 @@ class Lhmp extends Protocol
         $result->add('password', $buffer->readString());
         $result->add('numplayers', $buffer->readInt16());
         $result->add('maxplayers', $buffer->readInt16());
-        $result->add('servername', utf8_encode($buffer->readPascalString()));
+        $result->add('servername',  mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
         $result->add('gamemode', $buffer->readPascalString());
-        $result->add('website', utf8_encode($buffer->readPascalString()));
-        $result->add('mapname', utf8_encode($buffer->readPascalString()));
+        $result->add('website',  mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
+        $result->add('mapname',  mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
 
         unset($buffer);
 
@@ -203,7 +203,7 @@ class Lhmp extends Protocol
             if (($id = $buffer->readInt16()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString()));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
             }
         }
 

--- a/src/GameQ/Protocols/M2mp.php
+++ b/src/GameQ/Protocols/M2mp.php
@@ -208,7 +208,7 @@ class M2mp extends Protocol
 
             // Only player name information is available
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readPascalString(1, true))));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readPascalString(1, true)), 'UTF-8'));
         }
 
         // Clear

--- a/src/GameQ/Protocols/Quake2.php
+++ b/src/GameQ/Protocols/Quake2.php
@@ -154,7 +154,7 @@ class Quake2 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                utf8_encode(trim($buffer->readStringMulti(['\\', "\x0a"])))
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), 'UTF-8')
             );
         }
 
@@ -194,8 +194,8 @@ class Quake2 extends Protocol
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim(($playerInfo->readString('"')))));
-
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), 'UTF-8'));
+            
             // Skip first "
             $playerInfo->skip(2);
 

--- a/src/GameQ/Protocols/Quake3.php
+++ b/src/GameQ/Protocols/Quake3.php
@@ -147,7 +147,7 @@ class Quake3 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                utf8_encode(trim($buffer->readStringMulti(['\\', "\x0a"])))
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), 'UTF-8')
             );
         }
 
@@ -195,7 +195,7 @@ class Quake3 extends Protocol
             }
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString('"'))));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString('"')), 'UTF-8'));
 
             // Burn ending delimiter
             $buffer->read();

--- a/src/GameQ/Protocols/Quake4.php
+++ b/src/GameQ/Protocols/Quake4.php
@@ -67,7 +67,7 @@ class Quake4 extends Doom3
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString())));
+            $result->addPlayer('name', mb_convert_encoding($buffer->readString(), 'UTF-8'));
             $result->addPlayer('clantag', $buffer->readString());
             // Increment
             $playerCount++;

--- a/src/GameQ/Protocols/Samp.php
+++ b/src/GameQ/Protocols/Samp.php
@@ -213,7 +213,7 @@ class Samp extends Protocol
         $result->add('max_players', $buffer->readInt16());
 
         // These are read differently for these last 3
-        $result->add('servername', utf8_encode($buffer->read($buffer->readInt32())));
+        $result->add('servername', mb_convert_encoding($buffer->readInt32(), 'UTF-8'));
         $result->add('gametype', $buffer->read($buffer->readInt32()));
         $result->add('language', $buffer->read($buffer->readInt32()));
 
@@ -241,7 +241,7 @@ class Samp extends Protocol
         // Run until we run out of buffer
         while ($buffer->getLength()) {
             $result->addPlayer('id', $buffer->readInt8());
-            $result->addPlayer('name', utf8_encode($buffer->readPascalString()));
+            $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), 'UTF-8'));
             $result->addPlayer('score', $buffer->readInt32());
             $result->addPlayer('ping', $buffer->readInt32());
         }

--- a/src/GameQ/Protocols/Teamspeak2.php
+++ b/src/GameQ/Protocols/Teamspeak2.php
@@ -218,7 +218,7 @@ class Teamspeak2 extends Protocol
             list($key, $value) = explode('=', $row, 2);
 
             // Add this to the result
-            $result->add($key, utf8_encode($value));
+            $result->add($key, mb_convert_encoding($value, 'UTF-8'));
         }
 
         unset($data, $buffer, $row, $key, $value);
@@ -249,7 +249,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addTeam($key, utf8_encode($value));
+                $result->addTeam($key, mb_convert_encoding($value, 'UTF-8'));
             }
         }
 
@@ -281,7 +281,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addPlayer($key, utf8_encode($value));
+                $result->addPlayer($key, mb_convert_encoding($value, 'UTF-8'));
             }
         }
 

--- a/src/GameQ/Protocols/Teamspeak3.php
+++ b/src/GameQ/Protocols/Teamspeak3.php
@@ -231,7 +231,7 @@ class Teamspeak3 extends Protocol
             list($key, $value) = array_pad(explode('=', $item, 2), 2, '');
 
             // Convert spaces and other character changes
-            $properties[$key] = utf8_encode(str_replace(
+            $properties[$key] = mb_convert_encoding(str_replace(
                 [
                     '\\s', // Translate spaces
                 ],
@@ -239,7 +239,7 @@ class Teamspeak3 extends Protocol
                     ' ',
                 ],
                 $value
-            ));
+            ), 'UTF-8');
         }
 
         return $properties;

--- a/src/GameQ/Protocols/Unreal2.php
+++ b/src/GameQ/Protocols/Unreal2.php
@@ -167,8 +167,8 @@ class Unreal2 extends Protocol
         $result->add('serverip', $buffer->readPascalString(1)); // empty
         $result->add('gameport', $buffer->readInt32());
         $result->add('queryport', $buffer->readInt32()); // 0
-        $result->add('servername', utf8_encode($buffer->readPascalString(1)));
-        $result->add('mapname', utf8_encode($buffer->readPascalString(1)));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(1), 'UTF-8'));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), 'UTF-8'));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());
@@ -198,7 +198,7 @@ class Unreal2 extends Protocol
             if (($id = $buffer->readInt32()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString(1)));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(1), 'UTF-8'));
                 $result->addPlayer('ping', $buffer->readInt32());
                 $result->addPlayer('score', $buffer->readInt32());
 
@@ -236,7 +236,7 @@ class Unreal2 extends Protocol
                 $key .= ++$inc;
             }
 
-            $result->add(strtolower($key), utf8_encode($buffer->readPascalString(1)));
+            $result->add(strtolower($key), mb_convert_encoding($buffer->readPascalString(1), 'UTF-8'));
         }
 
         unset($buffer);

--- a/src/GameQ/Protocols/Ventrilo.php
+++ b/src/GameQ/Protocols/Ventrilo.php
@@ -723,7 +723,7 @@ class Ventrilo extends Protocol
 
                     // By default we just add they key as an item
                     default:
-                        $result->add($key, utf8_encode($value));
+                        $result->add($key, mb_convert_encoding($value, 'UTF-8'));
                         break;
                 }
             }
@@ -849,7 +849,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addTeam(strtolower($key), utf8_encode($value));
+            $result->addTeam(strtolower($key), mb_convert_encoding($value, 'UTF-8'));
         }
     }
 
@@ -871,7 +871,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addPlayer(strtolower($key), utf8_encode($value));
+            $result->addPlayer(strtolower($key), mb_convert_encoding($value, 'UTF-8'));
         }
     }
 }

--- a/src/GameQ/Protocols/Warsow.php
+++ b/src/GameQ/Protocols/Warsow.php
@@ -76,8 +76,8 @@ class Warsow extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim(($playerInfo->readString('"')))));
-
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), 'UTF-8'));
+            
             // Skip space
             $playerInfo->skip(1);
 

--- a/src/GameQ/Server.php
+++ b/src/GameQ/Server.php
@@ -38,6 +38,8 @@ class Server
 
     const SERVER_OPTIONS = 'options';
 
+    const SERVER_CUSTOM = 'custom';
+
     /*
      * Server options keys
      */
@@ -81,6 +83,13 @@ class Server
      * @type int
      */
     public $port_query = null;
+
+    /**
+     * The server's custom data
+     *
+     * @type array
+     */
+    public $custom = [];
 
     /**
      * Holds other server specific options
@@ -132,6 +141,12 @@ class Server
         if (array_key_exists(self::SERVER_OPTIONS, $server_info)) {
             // Set the options
             $this->options = $server_info[self::SERVER_OPTIONS];
+        }
+
+        // Check and set custom parameters
+        if (array_key_exists(self::SERVER_CUSTOM, $server_info)) {
+            // Set the parameters
+            $this->custom = $server_info[self::SERVER_CUSTOM];
         }
 
         try {
@@ -385,5 +400,15 @@ class Server
 
         // Reset the sockets list
         $this->sockets = [];
+    }
+
+    /**
+     * Get custom parameters
+     *
+     * @return array
+     */
+    public function getCustom()
+    {
+        return $this->custom;
     }
 }


### PR DESCRIPTION
Add ability to pass custom parameters per server.

## Example:
```php
$GameQ = new \GameQ\GameQ();
$GameQ->addServer([
    'type' => 'css',
    'host' => '127.0.0.1:27015',
    'custom' => [
        'key_1' => 'data_1'
    ]
]);
$results = $GameQ->process();
```

## Can be accessed:
```php
print_r($results['gq_custom']);
```

Result _accessed via print_r($results)_
![image](https://github.com/Austinb/GameQ/assets/99070546/31a898c1-5fc8-422e-9764-4e56514aba73)


