### PR TITLE
[Fix] Epic Online Services protocol unit tests

### DIFF
--- a/src/GameQ/Protocols/Eos.php
+++ b/src/GameQ/Protocols/Eos.php
@@ -138,7 +138,7 @@ class Eos extends Http
      *
      * @param Server $server
      */
-    public function beforeSend($server)
+    public function beforeSend(Server $server)
     {
         $this->serverIp = $server->ip();
         $this->serverPortQuery = $server->portQuery();
@@ -274,7 +274,7 @@ class Eos extends Http
      * @param mixed $default
      * @return mixed
      */
-    protected function getAttribute(array $attributes, string $key, $default = null)
+    protected function getAttribute($attributes, $key, $default = null)
     {
         return isset($attributes[$key]) ? $attributes[$key] : $default;
     }


### PR DESCRIPTION
This pull request will fix the issues introduced by the Epic Online Services Protocol by:
- Changing signature of `beforeSend()` to match the parent implementation.
- Remove primitive method parameter type hints as those are not supported before PHP 7.